### PR TITLE
Move chat logic into separate service

### DIFF
--- a/packages/kbn-es-types/src/search.ts
+++ b/packages/kbn-es-types/src/search.ts
@@ -162,6 +162,20 @@ export type AggregateOf<
       cardinality: {
         value: number;
       };
+      change_point: {
+        bucket?: {
+          key: string;
+        };
+        type: Record<
+          string,
+          {
+            change_point?: number;
+            r_value?: number;
+            trend?: string;
+            p_value: number;
+          }
+        >;
+      };
       children: {
         doc_count: number;
       } & SubAggregateOf<TAggregationContainer, TDocument>;

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_correlations.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_correlations.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/common/types';
+
+export function registerGetApmCorrelationsFunction({
+  registerFunction,
+}: {
+  registerFunction: RegisterFunctionDefinition;
+}) {}

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_downstream_dependencies.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_downstream_dependencies.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/common/types';
+
+export function registerGetApmDownstreamDependenciesFunction({
+  registerFunction,
+}: {
+  registerFunction: RegisterFunctionDefinition;
+}) {}

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_error_document.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_error_document.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/common/types';
+
+export function registerGetApmErrorDocumentFunction({
+  registerFunction,
+}: {
+  registerFunction: RegisterFunctionDefinition;
+}) {}

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_service_summary.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_service_summary.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/common/types';
+
+export function registerGetApmServiceSummaryFunction({
+  registerFunction,
+}: {
+  registerFunction: RegisterFunctionDefinition;
+}) {}

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_timeseries.tsx
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_timeseries.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { CoreStart } from '@kbn/core/public';
+import { groupBy } from 'lodash';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { ApmPluginStartDeps } from '../../plugin';
+import {
+  callApmApi,
+  createCallApmApi,
+} from '../../services/rest/create_call_apm_api';
+
+export function registerGetApmTimeseriesFunction({
+  pluginsStart,
+  coreStart,
+}: {
+  pluginsStart: ApmPluginStartDeps;
+  coreStart: CoreStart;
+}) {
+  createCallApmApi(coreStart);
+
+  pluginsStart.observabilityAIAssistant.registerFunction(
+    {
+      contexts: ['apm'],
+      name: 'get_apm_timeseries',
+      descriptionForUser: `Display different APM metrics, like throughput, failure rate, or latency, for any service or all services, or any or all of its dependencies, both as a timeseries and as a single statistic. Additionally, the function will return any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or for instance two different service versions`,
+      description: `Display different APM metrics, like throughput, failure rate, or latency, for any service or all services, or any or all of its dependencies, both as a timeseries and as a single statistic. Additionally, the function will return any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or for instance two different service versions. In KQL, escaping happens with double quotes, not single quotes. Some characters that need escaping are: ':()\\\/\". Always put a field value in double quotes. Best: service.name:\"opbeans-go\". Wrong: service.name:opbeans-go. This is very important!`,
+      parameters: {
+        type: 'object',
+        properties: {
+          start: {
+            type: 'string',
+            description:
+              'The start of the time range, in Elasticsearch date math, like `now`.',
+          },
+          end: {
+            type: 'string',
+            description:
+              'The end of the time range, in Elasticsearch date math, like `now-24h`.',
+          },
+          stats: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                timeseries: {
+                  description: 'The metric to be displayed',
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                          enum: [
+                            'transaction_throughput',
+                            'transaction_failure_rate',
+                          ],
+                        },
+                        'transaction.type': {
+                          type: 'string',
+                          description: 'The transaction type',
+                        },
+                      },
+                      required: ['name'],
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                          enum: [
+                            'exit_span_throughput',
+                            'exit_span_failure_rate',
+                            'exit_span_latency',
+                          ],
+                        },
+                        'span.destination.service.resource': {
+                          type: 'string',
+                          description:
+                            'The name of the downstream dependency for the service',
+                        },
+                      },
+                      required: ['name'],
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                          const: 'error_event_rate',
+                        },
+                      },
+                      required: ['name'],
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                          const: 'transaction_latency',
+                        },
+                        'transaction.type': {
+                          type: 'string',
+                        },
+                        function: {
+                          type: 'string',
+                          enum: ['avg', 'p95', 'p99'],
+                        },
+                      },
+                      required: ['name', 'function'],
+                    },
+                  ],
+                },
+                'service.name': {
+                  type: 'string',
+                  description: 'The name of the service',
+                },
+                'service.environment': {
+                  type: 'string',
+                  description: 'The environment that the service is running in',
+                },
+                filter: {
+                  type: 'string',
+                  description:
+                    'a KQL query to filter the data by. If no filter should be applied, leave it empty.',
+                },
+                title: {
+                  type: 'string',
+                  description:
+                    'A unique, human readable, concise title for this specific group series.',
+                },
+                offset: {
+                  type: 'string',
+                  description:
+                    'The offset. Right: 15m. 8h. 1d. Wrong: -15m. -8h. -1d.',
+                },
+              },
+              required: [
+                'service.name',
+                'service.environment',
+                'timeseries',
+                'title',
+              ],
+            },
+          },
+        },
+        required: ['stats', 'start', 'end'],
+      } as const,
+    },
+    async ({ arguments: { stats, start, end } }, signal) => {
+      const response = await callApmApi(
+        'POST /internal/apm/assistant/get_apm_timeseries',
+        {
+          signal,
+          params: {
+            body: { stats: stats as any, start, end },
+          },
+        }
+      );
+
+      return response;
+    },
+    ({ arguments: args, response }) => {
+      const groupedSeries = groupBy(response.data, (series) => series.group);
+
+      return (
+        <EuiFlexGroup direction="column">
+          {Object.values(groupedSeries).map((groupSeries) => {
+            const groupId = groupSeries[0].group;
+
+            return (
+              <EuiFlexItem grow={false} key={groupId}>
+                <EuiFlexGroup direction="column" gutterSize="s">
+                  <EuiFlexItem>
+                    <EuiText size="m">{groupId}</EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            );
+          })}
+        </EuiFlexGroup>
+      );
+    }
+  );
+}

--- a/x-pack/plugins/apm/public/components/assistant_functions/get_apm_timeseries.tsx
+++ b/x-pack/plugins/apm/public/components/assistant_functions/get_apm_timeseries.tsx
@@ -4,26 +4,39 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { CoreStart } from '@kbn/core/public';
-import { groupBy } from 'lodash';
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { ApmPluginStartDeps } from '../../plugin';
+import type { RegisterFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/common/types';
+import { groupBy } from 'lodash';
+import React from 'react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { FETCH_STATUS } from '../../hooks/use_fetcher';
+import { callApmApi } from '../../services/rest/create_call_apm_api';
+import { getTimeZone } from '../shared/charts/helper/timezone';
+import { TimeseriesChart } from '../shared/charts/timeseries_chart';
+import { ChartPointerEventContextProvider } from '../../context/chart_pointer_event/chart_pointer_event_context';
+import { ApmThemeProvider } from '../routing/app_root';
+import { Coordinate, TimeSeries } from '../../../typings/timeseries';
 import {
-  callApmApi,
-  createCallApmApi,
-} from '../../services/rest/create_call_apm_api';
+  ChartType,
+  getTimeSeriesColor,
+} from '../shared/charts/helper/get_timeseries_color';
+import { LatencyAggregationType } from '../../../common/latency_aggregation_types';
+import {
+  asPercent,
+  asTransactionRate,
+  getDurationFormatter,
+} from '../../../common/utils/formatters';
+import {
+  getMaxY,
+  getResponseTimeTickFormatter,
+} from '../shared/charts/transaction_charts/helper';
 
 export function registerGetApmTimeseriesFunction({
-  pluginsStart,
-  coreStart,
+  registerFunction,
 }: {
-  pluginsStart: ApmPluginStartDeps;
-  coreStart: CoreStart;
+  registerFunction: RegisterFunctionDefinition;
 }) {
-  createCallApmApi(coreStart);
-
-  pluginsStart.observabilityAIAssistant.registerFunction(
+  registerFunction(
     {
       contexts: ['apm'],
       name: 'get_apm_timeseries',
@@ -121,7 +134,8 @@ export function registerGetApmTimeseriesFunction({
                 },
                 'service.environment': {
                   type: 'string',
-                  description: 'The environment that the service is running in',
+                  description:
+                    "The environment that the service is running in. If you don't know this, use ENVIRONMENT_ALL.",
                 },
                 filter: {
                   type: 'string',
@@ -167,22 +181,114 @@ export function registerGetApmTimeseriesFunction({
     ({ arguments: args, response }) => {
       const groupedSeries = groupBy(response.data, (series) => series.group);
 
-      return (
-        <EuiFlexGroup direction="column">
-          {Object.values(groupedSeries).map((groupSeries) => {
-            const groupId = groupSeries[0].group;
+      const {
+        services: { uiSettings },
+      } = useKibana();
 
-            return (
-              <EuiFlexItem grow={false} key={groupId}>
-                <EuiFlexGroup direction="column" gutterSize="s">
-                  <EuiFlexItem>
-                    <EuiText size="m">{groupId}</EuiText>
+      const timeZone = getTimeZone(uiSettings);
+
+      return (
+        <ChartPointerEventContextProvider>
+          <ApmThemeProvider>
+            <EuiFlexGroup direction="column">
+              {Object.values(groupedSeries).map((groupSeries) => {
+                const groupId = groupSeries[0].group;
+
+                const maxY = getMaxY(groupSeries);
+                const latencyFormatter = getDurationFormatter(maxY);
+
+                let yLabelFormat: (value: number) => string;
+
+                const firstStat = groupSeries[0].stat;
+
+                switch (firstStat.timeseries.name) {
+                  case 'transaction_throughput':
+                  case 'exit_span_throughput':
+                  case 'error_event_rate':
+                    yLabelFormat = asTransactionRate;
+                    break;
+
+                  case 'transaction_latency':
+                  case 'exit_span_latency':
+                    yLabelFormat =
+                      getResponseTimeTickFormatter(latencyFormatter);
+                    break;
+
+                  case 'transaction_failure_rate':
+                  case 'exit_span_failure_rate':
+                    yLabelFormat = (y) => asPercent(y || 0, 100);
+                    break;
+                }
+
+                const timeseries: Array<TimeSeries<Coordinate>> =
+                  groupSeries.map((series): TimeSeries<Coordinate> => {
+                    let chartType: ChartType;
+
+                    switch (series.stat.timeseries.name) {
+                      case 'transaction_throughput':
+                      case 'exit_span_throughput':
+                        chartType = ChartType.THROUGHPUT;
+                        break;
+
+                      case 'transaction_failure_rate':
+                      case 'exit_span_failure_rate':
+                        chartType = ChartType.FAILED_TRANSACTION_RATE;
+                        break;
+
+                      case 'transaction_latency':
+                        if (
+                          series.stat.timeseries.function ===
+                          LatencyAggregationType.p99
+                        ) {
+                          chartType = ChartType.LATENCY_P99;
+                        } else if (
+                          series.stat.timeseries.function ===
+                          LatencyAggregationType.p95
+                        ) {
+                          chartType = ChartType.LATENCY_P95;
+                        } else {
+                          chartType = ChartType.LATENCY_AVG;
+                        }
+                        break;
+
+                      case 'exit_span_latency':
+                        chartType = ChartType.LATENCY_AVG;
+                        break;
+
+                      case 'error_event_rate':
+                        chartType = ChartType.ERROR_OCCURRENCES;
+                        break;
+                    }
+
+                    return {
+                      title: series.id,
+                      type: 'line',
+                      color: getTimeSeriesColor(chartType!).currentPeriodColor,
+                      data: series.data,
+                    };
+                  });
+
+                return (
+                  <EuiFlexItem grow={false} key={groupId}>
+                    <EuiFlexGroup direction="column" gutterSize="s">
+                      <EuiFlexItem>
+                        <EuiText size="m">{groupId}</EuiText>
+                        <TimeseriesChart
+                          comparisonEnabled={false}
+                          fetchStatus={FETCH_STATUS.SUCCESS}
+                          id={groupId}
+                          timeZone={timeZone}
+                          timeseries={timeseries}
+                          yLabelFormat={yLabelFormat!}
+                        />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
                   </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-            );
-          })}
-        </EuiFlexGroup>
+                );
+              })}
+            </EuiFlexGroup>
+          </ApmThemeProvider>
+        </ChartPointerEventContextProvider>
       );
     }
   );

--- a/x-pack/plugins/apm/public/components/assistant_functions/index.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/index.ts
@@ -5,20 +5,124 @@
  * 2.0.
  */
 
+import { CoreStart } from '@kbn/core/public';
 import { ApmPluginStartDeps } from '../../plugin';
+import { createCallApmApi } from '../../services/rest/create_call_apm_api';
+import { registerGetApmCorrelationsFunction } from './get_apm_correlations';
+import { registerGetApmDownstreamDependenciesFunction } from './get_apm_downstream_dependencies';
+import { registerGetApmErrorDocumentFunction } from './get_apm_error_document';
+import { registerGetApmServiceSummaryFunction } from './get_apm_service_summary';
 import { registerGetApmTimeseriesFunction } from './get_apm_timeseries';
 
 export function registerAssistantFunctions({
   pluginsStart,
+  coreStart,
 }: {
   pluginsStart: ApmPluginStartDeps;
+  coreStart: CoreStart;
 }) {
-  pluginsStart.observabilityAIAssistant.registerContext({
-    name: 'apm',
-    description: 'Tools for APM',
-  });
+  createCallApmApi(coreStart);
 
-  registerGetApmTimeseriesFunction({
-    pluginsStart,
-  });
+  pluginsStart.observabilityAIAssistant.register(
+    async ({ signal, registerContext, registerFunction }) => {
+      registerGetApmTimeseriesFunction({
+        registerFunction,
+      });
+
+      registerGetApmErrorDocumentFunction({
+        registerFunction,
+      });
+
+      registerGetApmCorrelationsFunction({
+        registerFunction,
+      });
+
+      registerGetApmDownstreamDependenciesFunction({
+        registerFunction,
+      });
+
+      registerGetApmServiceSummaryFunction({
+        registerFunction,
+      });
+
+      registerContext({
+        name: 'apm',
+        description: `
+There are four important data types in Elastic APM. Each of them have the 
+following fields:
+- service.name: the name of the service
+- service.node.name: the id of the service instance (often the hostname)
+- service.environment: the environment (often production, development)
+- agent.name: the name of the agent (go, java, etc)
+
+The four data types are transactions, exit spans, error events, and application 
+metrics.
+
+Transactions have three metrics: throughput, failure rate, and latency. The 
+fields are:
+
+- transaction.type: often request or page-load (the main transaction types), 
+but can also be worker, or route-change.
+- transaction.name: The name of the transaction group, often something like 
+'GET /api/product/:productId'
+- transaction.result: The result. Used to capture HTTP response codes 
+(2xx,3xx,4xx,5xx) for request transactions.
+- event.outcome: whether the transaction was succesful or not. success, 
+failure, or unknown.
+
+Exit spans have three metrics: throughput, failure rate and latency. The fields 
+are:
+- span.type: db, external
+- span.subtype: the type of database (redis, postgres) or protocol (http, grpc)
+- span.destination.service.resource: the address of the destination of the call
+- event.outcome: whether the transaction was succesful or not. success, 
+failure, or unknown.
+
+Error events have one metric, error event rate. The fields are:
+- error.grouping_name: a human readable keyword that identifies the error group
+
+For transaction metrics we also collect anomalies. These are scored 0 (low) to 
+100 (critical).
+
+For root cause analysis, locate a change point in the relevant metrics for a 
+service or downstream dependency. You can locate a change point by using a 
+sliding window, e.g. start with a small time range, like 30m, and make it 
+bigger until you identify a change point. It's very important to identify a 
+change point. If you don't have a change point, ask the user for next steps. 
+You can also use an anomaly or a deployment as a change point. Then, compare 
+data before the change with data after the change. You can either use the 
+groupBy parameter in get_apm_chart to get the most occuring values in a certain 
+data set, or you can use correlations to see for which field and value the 
+frequency has changed when comparing the foreground set to the background set. 
+This is useful when comparing data from before the change point with after the 
+change point. For instance, you might see a specific error pop up more often 
+after the change point.
+
+When comparing anomalies and changes in timeseries, first, zoom in to a smaller 
+time window, at least 30 minutes before and 30 minutes after the change 
+occured. E.g., if the anomaly occured at 2023-07-05T08:15:00.000Z, request a 
+time window that starts at 2023-07-05T07:45:00.000Z and ends at 
+2023-07-05T08:45:00.000Z. When comparing changes in different timeseries and 
+anomalies to determine a correlation, make sure to compare the timestamps. If 
+in doubt, rate the likelihood of them being related, given the time difference, 
+between 1 and 10. If below 5, assume it's not related. Mention this likelihood 
+(and the time difference) to the user.
+
+Your goal is to help the user determine the root cause of an issue quickly and 
+transparently. If you see a change or 
+anomaly in a metric for a service, try to find similar changes in the metrics 
+for the traffic to its downstream dependencies, by comparing transaction 
+metrics to span metrics. To inspect the traffic from one service to a 
+downstream dependency, first get the downstream dependencies for a service, 
+then get the span metrics from that service (\`service.name\`) to its 
+downstream dependency (\`span.destination.service.resource\`). For instance, 
+for an anomaly in throughput, first inspect \`transaction_throughput\` for 
+\`service.name\`. Then, inspect \`exit_span_throughput\` for its downstream 
+dependencies, by grouping by \`span.destination.service.resource\`. Repeat this 
+process over the next service its downstream dependencies until you identify a 
+root cause. If you can not find any similar changes, use correlations or 
+grouping to find attributes that could be causes for the change.`,
+      });
+    }
+  );
 }

--- a/x-pack/plugins/apm/public/components/assistant_functions/index.ts
+++ b/x-pack/plugins/apm/public/components/assistant_functions/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ApmPluginStartDeps } from '../../plugin';
+import { registerGetApmTimeseriesFunction } from './get_apm_timeseries';
+
+export function registerAssistantFunctions({
+  pluginsStart,
+}: {
+  pluginsStart: ApmPluginStartDeps;
+}) {
+  pluginsStart.observabilityAIAssistant.registerContext({
+    name: 'apm',
+    description: 'Tools for APM',
+  });
+
+  registerGetApmTimeseriesFunction({
+    pluginsStart,
+  });
+}

--- a/x-pack/plugins/apm/public/components/routing/app_root/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root/index.tsx
@@ -127,7 +127,7 @@ function MountApmHeaderActionMenu() {
   );
 }
 
-function ApmThemeProvider({ children }: { children: React.ReactNode }) {
+export function ApmThemeProvider({ children }: { children: React.ReactNode }) {
   const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
 
   return (

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -73,7 +73,7 @@ import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import type { ConfigSchema } from '.';
 import { registerApmRuleTypes } from './components/alerting/rule_types/register_apm_rule_types';
-import { registerGetApmTimeseriesFunction } from './components/assistant_functions/get_apm_timeseries';
+import { registerAssistantFunctions } from './components/assistant_functions';
 import {
   getApmEnrollmentFlyoutData,
   LazyApmCustomAssetsExtension,
@@ -415,9 +415,9 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
   public start(core: CoreStart, plugins: ApmPluginStartDeps) {
     const { fleet } = plugins;
 
-    registerGetApmTimeseriesFunction({
-      pluginsStart: plugins,
+    registerAssistantFunctions({
       coreStart: core,
+      pluginsStart: plugins,
     });
 
     if (fleet) {

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import { from } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type {
+  PluginSetupContract as AlertingPluginPublicSetup,
+  PluginStartContract as AlertingPluginPublicStart,
+} from '@kbn/alerting-plugin/public';
+import { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import {
   AppMountParameters,
   AppNavLinkStatus,
@@ -19,59 +20,60 @@ import {
   PluginInitializerContext,
 } from '@kbn/core/public';
 import type {
-  DataPublicPluginStart,
   DataPublicPluginSetup,
+  DataPublicPluginStart,
 } from '@kbn/data-plugin/public';
-import { LensPublicStart } from '@kbn/lens-plugin/public';
-import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
-import type { ExploratoryViewPublicSetup } from '@kbn/exploratory-view-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import {
+  DiscoverSetup,
+  DiscoverStart,
+} from '@kbn/discover-plugin/public/plugin';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
-import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
-import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
-import type {
-  PluginSetupContract as AlertingPluginPublicSetup,
-  PluginStartContract as AlertingPluginPublicStart,
-} from '@kbn/alerting-plugin/public';
-import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import type { ExploratoryViewPublicSetup } from '@kbn/exploratory-view-plugin/public';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/public';
+import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { FleetStart } from '@kbn/fleet-plugin/public';
+import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { InfraClientStartExports } from '@kbn/infra-plugin/public';
+import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
+import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import { LensPublicStart } from '@kbn/lens-plugin/public';
+import { LicenseManagementUIPluginSetup } from '@kbn/license-management-plugin/public';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
 import type { MapsStartApi } from '@kbn/maps-plugin/public';
 import type { MlPluginSetup, MlPluginStart } from '@kbn/ml-plugin/public';
-import type { SharePluginSetup } from '@kbn/share-plugin/public';
-import type {
-  ObservabilitySharedPluginSetup,
-  ObservabilitySharedPluginStart,
-} from '@kbn/observability-shared-plugin/public';
+import type { ObservabilityAIAssistantPluginStart } from '@kbn/observability-ai-assistant-plugin/public';
 import {
   FetchDataParams,
   ObservabilityPublicSetup,
   ObservabilityPublicStart,
 } from '@kbn/observability-plugin/public';
-import { METRIC_TYPE } from '@kbn/observability-shared-plugin/public';
-import type {
-  TriggersAndActionsUIPublicPluginSetup,
-  TriggersAndActionsUIPublicPluginStart,
-} from '@kbn/triggers-actions-ui-plugin/public';
-import type { SecurityPluginStart } from '@kbn/security-plugin/public';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/public';
-import { InfraClientStartExports } from '@kbn/infra-plugin/public';
-import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
-import { ChartsPluginStart } from '@kbn/charts-plugin/public';
-import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import { UiActionsStart, UiActionsSetup } from '@kbn/ui-actions-plugin/public';
 import { ObservabilityTriggerId } from '@kbn/observability-shared-plugin/common';
-import { LicenseManagementUIPluginSetup } from '@kbn/license-management-plugin/public';
+import type {
+  ObservabilitySharedPluginSetup,
+  ObservabilitySharedPluginStart,
+} from '@kbn/observability-shared-plugin/public';
+import { METRIC_TYPE } from '@kbn/observability-shared-plugin/public';
 import {
   ProfilingPluginSetup,
   ProfilingPluginStart,
 } from '@kbn/profiling-plugin/public';
-import {
-  DiscoverStart,
-  DiscoverSetup,
-} from '@kbn/discover-plugin/public/plugin';
-import type { ObservabilityAIAssistantPluginStart } from '@kbn/observability-ai-assistant-plugin/public';
+import type { SecurityPluginStart } from '@kbn/security-plugin/public';
+import type { SharePluginSetup } from '@kbn/share-plugin/public';
+import { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import type {
+  TriggersAndActionsUIPublicPluginSetup,
+  TriggersAndActionsUIPublicPluginStart,
+} from '@kbn/triggers-actions-ui-plugin/public';
+import { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import { from } from 'rxjs';
+import { map } from 'rxjs/operators';
+import type { ConfigSchema } from '.';
 import { registerApmRuleTypes } from './components/alerting/rule_types/register_apm_rule_types';
+import { registerGetApmTimeseriesFunction } from './components/assistant_functions/get_apm_timeseries';
 import {
   getApmEnrollmentFlyoutData,
   LazyApmCustomAssetsExtension,
@@ -80,7 +82,6 @@ import { getLazyApmAgentsTabExtension } from './components/fleet_integration/laz
 import { getLazyAPMPolicyCreateExtension } from './components/fleet_integration/lazy_apm_policy_create_extension';
 import { getLazyAPMPolicyEditExtension } from './components/fleet_integration/lazy_apm_policy_edit_extension';
 import { featureCatalogueEntry } from './feature_catalogue_entry';
-import type { ConfigSchema } from '.';
 import { APMServiceDetailLocator } from './locator/service_detail_locator';
 
 export type ApmPluginSetup = ReturnType<ApmPlugin['setup']>;
@@ -413,6 +414,12 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
 
   public start(core: CoreStart, plugins: ApmPluginStartDeps) {
     const { fleet } = plugins;
+
+    registerGetApmTimeseriesFunction({
+      pluginsStart: plugins,
+      coreStart: core,
+    });
+
     if (fleet) {
       const agentEnrollmentExtensionData = getApmEnrollmentFlyoutData();
 

--- a/x-pack/plugins/apm/server/routes/apm_routes/get_global_apm_server_route_repository.ts
+++ b/x-pack/plugins/apm/server/routes/apm_routes/get_global_apm_server_route_repository.ts
@@ -44,6 +44,7 @@ import { suggestionsRouteRepository } from '../suggestions/route';
 import { timeRangeMetadataRoute } from '../time_range_metadata/route';
 import { traceRouteRepository } from '../traces/route';
 import { transactionRouteRepository } from '../transactions/route';
+import { assistantRouteRepository } from '../assistant_functions/route';
 
 function getTypedGlobalApmServerRouteRepository() {
   const repository = {
@@ -81,6 +82,7 @@ function getTypedGlobalApmServerRouteRepository() {
     ...agentExplorerRouteRepository,
     ...mobileRouteRepository,
     ...diagnosticsRepository,
+    ...assistantRouteRepository,
   };
 
   return repository;

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/fetch_timeseries.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/fetch_timeseries.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AggregationsAggregationContainer,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+import { AggregationResultOf, AggregationResultOfMap } from '@kbn/es-types';
+import { Unionize } from 'utility-types';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { RollupInterval } from '../../../../common/rollup';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+
+type ChangePointResult = AggregationResultOf<{ change_point: any }, unknown>;
+
+type ValueAggregationMap = Record<
+  'value',
+  Unionize<
+    Pick<
+      Required<AggregationsAggregationContainer>,
+      'min' | 'max' | 'sum' | 'bucket_script' | 'avg'
+    >
+  >
+>;
+
+interface ApmFetchedTimeseries<T extends ValueAggregationMap> {
+  groupBy: string;
+  data: Array<
+    {
+      key: number;
+      key_as_string: string;
+      doc_count: number;
+    } & AggregationResultOfMap<T, unknown>
+  >;
+  change_point: ChangePointResult;
+  value: number | null;
+  unit: string;
+}
+
+export interface FetchSeriesProps<T extends ValueAggregationMap> {
+  apmEventClient: APMEventClient;
+  operationName: string;
+  documentType: ApmDocumentType;
+  rollupInterval: RollupInterval;
+  intervalString: string;
+  start: number;
+  end: number;
+  filter?: QueryDslQueryContainer[];
+  groupBy?: string;
+  aggs: T;
+  unit: 'ms' | 'rpm' | '%';
+}
+
+export async function fetchSeries<T extends ValueAggregationMap>({
+  apmEventClient,
+  operationName,
+  documentType,
+  rollupInterval,
+  intervalString,
+  start,
+  end,
+  filter,
+  groupBy,
+  aggs,
+  unit,
+}: FetchSeriesProps<T>): Promise<Array<ApmFetchedTimeseries<T>>> {
+  const response = await apmEventClient.search(operationName, {
+    apm: {
+      sources: [{ documentType, rollupInterval }],
+    },
+    body: {
+      size: 0,
+      track_total_hits: false,
+      query: {
+        bool: {
+          filter,
+        },
+      },
+      aggs: {
+        groupBy: {
+          ...(groupBy
+            ? {
+                terms: {
+                  field: groupBy,
+                  size: 20,
+                },
+              }
+            : {
+                terms: {
+                  field: 'non_existing_field',
+                  missing: '',
+                },
+              }),
+          aggs: {
+            ...aggs,
+            timeseries: {
+              date_histogram: {
+                field: '@timestamp',
+                fixed_interval: intervalString,
+                min_doc_count: 0,
+                extended_bounds: { min: start, max: end },
+              },
+              aggs,
+            },
+            change_point: {
+              change_point: {
+                buckets_path: 'timeseries>value',
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!response.aggregations?.groupBy) {
+    return [];
+  }
+
+  return response.aggregations.groupBy.buckets.map((bucket) => {
+    return {
+      groupBy: bucket.key_as_string || String(bucket.key),
+      data: bucket.timeseries.buckets,
+      value:
+        bucket.value?.value === undefined || bucket.value?.value === null
+          ? null
+          : Math.round(bucket.value.value),
+      change_point: bucket.change_point,
+      unit,
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_error_event_rate.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_error_event_rate.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getErrorEventRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_error_event_rate',
+      unit: 'rpm',
+      documentType: ApmDocumentType.ErrorEvent,
+      rollupInterval: RollupInterval.None,
+      intervalString,
+      filter: filter.concat(...rangeQuery(start, end)),
+      aggs: {
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value:
+        fetchedSerie.value !== null
+          ? fetchedSerie.value / rangeInMinutes
+          : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_failure_rate.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_failure_rate.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import {
+  EVENT_OUTCOME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+} from '../../../../common/es_fields/apm';
+import { EventOutcome } from '../../../../common/event_outcome';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanFailureRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_failure_rate',
+      unit: '%',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(
+          SPAN_DESTINATION_SERVICE_RESOURCE,
+          spanDestinationServiceResource
+        )
+      ),
+      groupBy: SPAN_DESTINATION_SERVICE_RESOURCE,
+      aggs: {
+        successful: {
+          filter: {
+            terms: {
+              [EVENT_OUTCOME]: [EventOutcome.success],
+            },
+          },
+          aggs: {
+            count: {
+              sum: {
+                field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+              },
+            },
+          },
+        },
+        successful_or_failed: {
+          filter: {
+            terms: {
+              [EVENT_OUTCOME]: [EventOutcome.success, EventOutcome.failure],
+            },
+          },
+          aggs: {
+            count: {
+              sum: {
+                field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+              },
+            },
+          },
+        },
+        value: {
+          bucket_script: {
+            buckets_path: {
+              successful_or_failed: `successful_or_failed>count`,
+              successful: `successful>count`,
+            },
+            script:
+              '100 * (1 - (params.successful / params.successful_or_failed))',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_latency.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_latency.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import {
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM,
+} from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanLatency({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_latency',
+      unit: 'rpm',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(
+          SPAN_DESTINATION_SERVICE_RESOURCE,
+          spanDestinationServiceResource
+        )
+      ),
+      groupBy: SPAN_DESTINATION_SERVICE_RESOURCE,
+      aggs: {
+        count: {
+          sum: {
+            field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+          },
+        },
+        latency: {
+          sum: {
+            field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM,
+          },
+        },
+        value: {
+          bucket_script: {
+            buckets_path: {
+              latency: 'latency',
+              count: 'count',
+            },
+            script: '(params.latency / params.count) / 1000',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_throughput.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_exit_span_throughput.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanThroughput({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_throughput',
+      unit: 'rpm',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(
+          SPAN_DESTINATION_SERVICE_RESOURCE,
+          spanDestinationServiceResource
+        )
+      ),
+      groupBy: SPAN_DESTINATION_SERVICE_RESOURCE,
+      aggs: {
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value:
+        fetchedSerie.value !== null
+          ? fetchedSerie.value / rangeInMinutes
+          : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_failure_rate.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_failure_rate.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { TRANSACTION_TYPE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getOutcomeAggregation } from '../../../lib/helpers/transaction_error_rate';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionFailureRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  transactionType,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_failure_rate',
+      unit: '%',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(TRANSACTION_TYPE, transactionType)
+      ),
+      groupBy: 'transaction.type',
+      aggs: {
+        ...getOutcomeAggregation(ApmDocumentType.TransactionMetric),
+        value: {
+          bucket_script: {
+            buckets_path: {
+              successful_or_failed: 'successful_or_failed>_count',
+              successful: 'successful>_count',
+            },
+            script:
+              '100 * (1 - (params.successful / params.successful_or_failed))',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_latency.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_latency.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import {
+  TRANSACTION_DURATION_HISTOGRAM,
+  TRANSACTION_TYPE,
+} from '../../../../common/es_fields/apm';
+import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
+import { RollupInterval } from '../../../../common/rollup';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getLatencyAggregation } from '../../../lib/helpers/latency_aggregation_type';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionLatency({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  transactionType,
+  latencyAggregationType,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+  latencyAggregationType: LatencyAggregationType;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_latencyu',
+      unit: 'rpm',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(TRANSACTION_TYPE, transactionType)
+      ),
+      groupBy: 'transaction.type',
+      aggs: {
+        ...getLatencyAggregation(
+          latencyAggregationType,
+          TRANSACTION_DURATION_HISTOGRAM
+        ),
+        value: {
+          bucket_script: {
+            buckets_path: {
+              latency: 'latency',
+            },
+            script: 'params.latency / 1000',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_throughput.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/get_transaction_throughput.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { TRANSACTION_TYPE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionThroughput({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+  transactionType,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_throughput',
+      unit: 'rpm',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...rangeQuery(start, end),
+        ...termQuery(TRANSACTION_TYPE, transactionType)
+      ),
+      groupBy: 'transaction.type',
+      aggs: {
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value:
+        fetchedSerie.value !== null
+          ? fetchedSerie.value / rangeInMinutes
+          : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/index.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/index.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
+import * as t from 'io-ts';
+import { SERVICE_NAME } from '../../../../common/es_fields/apm';
+import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
+import { environmentQuery } from '../../../../common/utils/environment_query';
+import { getBucketSize } from '../../../../common/utils/get_bucket_size';
+import { termQuery } from '../../../../common/utils/term_query';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { environmentRt } from '../../default_api_types';
+import { getErrorEventRate } from './get_error_event_rate';
+import { getExitSpanFailureRate } from './get_exit_span_failure_rate';
+import { getExitSpanLatency } from './get_exit_span_latency';
+import { getExitSpanThroughput } from './get_exit_span_throughput';
+import { getTransactionFailureRate } from './get_transaction_failure_rate';
+import { getTransactionLatency } from './get_transaction_latency';
+import { getTransactionThroughput } from './get_transaction_throughput';
+
+enum ApmTimeseriesType {
+  transactionThroughput = 'transaction_throughput',
+  transactionLatency = 'transaction_latency',
+  transactionFailureRate = 'transaction_failure_rate',
+  exitSpanThroughput = 'exit_span_throughput',
+  exitSpanLatency = 'exit_span_latency',
+  exitSpanFailureRate = 'exit_span_failure_rate',
+  errorEventRate = 'error_event_rate',
+}
+
+export const getApmTimeseriesRt = t.type({
+  stats: t.array(
+    t.intersection([
+      t.type({
+        'service.environment': environmentRt.props.environment,
+        'service.name': t.string,
+        title: t.string,
+        timeseries: t.union([
+          t.intersection([
+            t.type({
+              name: t.union([
+                t.literal(ApmTimeseriesType.transactionThroughput),
+                t.literal(ApmTimeseriesType.transactionFailureRate),
+              ]),
+            }),
+            t.partial({
+              'transaction.type': t.string,
+            }),
+          ]),
+          t.intersection([
+            t.type({
+              name: t.union([
+                t.literal(ApmTimeseriesType.exitSpanThroughput),
+                t.literal(ApmTimeseriesType.exitSpanFailureRate),
+                t.literal(ApmTimeseriesType.exitSpanLatency),
+              ]),
+            }),
+            t.partial({
+              'span.destination.service.resource': t.string,
+            }),
+          ]),
+          t.intersection([
+            t.type({
+              name: t.literal(ApmTimeseriesType.transactionLatency),
+              function: t.union([
+                t.literal(LatencyAggregationType.avg),
+                t.literal(LatencyAggregationType.p95),
+                t.literal(LatencyAggregationType.p99),
+              ]),
+            }),
+            t.partial({
+              'transaction.type': t.string,
+            }),
+          ]),
+          t.type({
+            name: t.literal(ApmTimeseriesType.errorEventRate),
+          }),
+        ]),
+      }),
+      t.partial({
+        filter: t.string,
+        offset: t.string,
+      }),
+    ])
+  ),
+  start: t.string,
+  end: t.string,
+});
+
+export interface ApmTimeseries {
+  group: string;
+  id: string;
+  data: Array<{ x: number; y: number | null }>;
+  value: number | null;
+  start: number;
+  end: number;
+  unit: string;
+  changes: Array<{
+    change_point?: number | undefined;
+    r_value?: number | undefined;
+    trend?: string | undefined;
+    p_value: number;
+    date: string | undefined;
+    type: string;
+  }>;
+}
+
+export async function getApmTimeseries({
+  arguments: args,
+  apmEventClient,
+}: {
+  arguments: t.TypeOf<typeof getApmTimeseriesRt>;
+  apmEventClient: APMEventClient;
+}): Promise<ApmTimeseries[]> {
+  const start = datemath.parse(args.start)!.valueOf();
+  const end = datemath.parse(args.end)!.valueOf();
+
+  const { bucketSize, intervalString } = getBucketSize({
+    start,
+    end,
+    numBuckets: 100,
+  });
+
+  const sharedParameters = {
+    apmEventClient,
+    start,
+    end,
+    bucketSize,
+    intervalString,
+  };
+
+  return (
+    await Promise.all(
+      args.stats.map(async (stat) => {
+        const parameters = {
+          ...sharedParameters,
+          filter: [
+            ...rangeQuery(start, end),
+            ...termQuery(SERVICE_NAME, stat['service.name']),
+            ...kqlQuery(stat.filter),
+            ...environmentQuery(stat['service.environment']),
+          ],
+        };
+        const name = stat.timeseries.name;
+
+        async function fetchSeriesForStat() {
+          switch (name) {
+            case ApmTimeseriesType.transactionThroughput:
+              return await getTransactionThroughput({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+              });
+
+            case ApmTimeseriesType.transactionFailureRate:
+              return await getTransactionFailureRate({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+              });
+
+            case ApmTimeseriesType.transactionLatency:
+              return await getTransactionLatency({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+                latencyAggregationType: stat.timeseries.function,
+              });
+
+            case ApmTimeseriesType.exitSpanThroughput:
+              return await getExitSpanThroughput({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.exitSpanFailureRate:
+              return await getExitSpanFailureRate({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.exitSpanLatency:
+              return await getExitSpanLatency({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.errorEventRate:
+              return await getErrorEventRate(parameters);
+          }
+        }
+
+        const allFetchedSeries = await fetchSeriesForStat();
+        return allFetchedSeries.map((series) => ({ ...series, stat }));
+      })
+    )
+  ).flatMap((statResults) =>
+    statResults.flatMap((statResult) => {
+      const changePointType = Object.keys(
+        statResult.change_point?.type ?? {}
+      )?.[0];
+
+      return {
+        group: statResult.stat.title,
+        id: statResult.groupBy,
+        data: statResult.data,
+        value: statResult.value,
+        start,
+        end,
+        unit: statResult.unit,
+        changes: [
+          ...(changePointType && changePointType !== 'indeterminable'
+            ? [
+                {
+                  date: statResult.change_point.bucket?.key,
+                  type: changePointType,
+                  ...statResult.change_point.type[changePointType],
+                },
+              ]
+            : []),
+        ],
+      };
+    })
+  );
+}

--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/index.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_timeseries/index.ts
@@ -23,7 +23,7 @@ import { getTransactionFailureRate } from './get_transaction_failure_rate';
 import { getTransactionLatency } from './get_transaction_latency';
 import { getTransactionThroughput } from './get_transaction_throughput';
 
-enum ApmTimeseriesType {
+export enum ApmTimeseriesType {
   transactionThroughput = 'transaction_throughput',
   transactionLatency = 'transaction_latency',
   transactionFailureRate = 'transaction_failure_rate',
@@ -92,7 +92,10 @@ export const getApmTimeseriesRt = t.type({
   end: t.string,
 });
 
+type ApmTimeseriesArgs = t.TypeOf<typeof getApmTimeseriesRt>;
+
 export interface ApmTimeseries {
+  stat: ApmTimeseriesArgs['stats'][number];
   group: string;
   id: string;
   data: Array<{ x: number; y: number | null }>;
@@ -206,6 +209,7 @@ export async function getApmTimeseries({
       )?.[0];
 
       return {
+        stat: statResult.stat,
         group: statResult.stat.title,
         id: statResult.groupBy,
         data: statResult.data,

--- a/x-pack/plugins/apm/server/routes/assistant_functions/route.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/route.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import * as t from 'io-ts';
+import { omit } from 'lodash';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
+import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
+import {
+  getApmTimeseriesRt,
+  getApmTimeseries,
+  ApmTimeseries,
+} from './get_apm_timeseries';
+
+const getApmTimeSeriesRoute = createApmServerRoute({
+  endpoint: 'POST /internal/apm/assistant/get_apm_timeseries',
+  options: {
+    tags: ['access:apm', 'access:ai_assistant'],
+  },
+  params: t.type({
+    body: getApmTimeseriesRt,
+  }),
+  handler: async (
+    resources
+  ): Promise<{
+    content: Array<Omit<ApmTimeseries, 'data'>>;
+    data: ApmTimeseries[];
+  }> => {
+    const body = resources.params.body;
+
+    const apmEventClient = await getApmEventClient(resources);
+
+    const timeseries = await getApmTimeseries({
+      apmEventClient,
+      arguments: body,
+    });
+
+    return {
+      content: timeseries.map(
+        (series): Omit<ApmTimeseries, 'data'> => omit(series, 'data')
+      ),
+      data: timeseries,
+    };
+  },
+});
+
+export const assistantRouteRepository = {
+  ...getApmTimeSeriesRoute,
+};

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -39,6 +39,7 @@ export interface APMRouteCreateOptions {
       | 'access:ml:canGetJobs'
       | 'access:ml:canCreateJob'
       | 'access:ml:canCloseJob'
+      | 'access:ai_assistant'
     >;
     body?: { accepts: Array<'application/json' | 'multipart/form-data'> };
     disableTelemetry?: boolean;

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -235,8 +235,6 @@ export class Plugin
       // Get start services
       const [coreStart, pluginsStart] = await coreSetup.getStartServices();
 
-      console.log(pluginsStart);
-
       const { ruleTypeRegistry, actionTypeRegistry } = pluginsStart.triggersActionsUi;
 
       return renderApp({

--- a/x-pack/plugins/observability_ai_assistant/common/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/types.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { Serializable } from '@kbn/utility-types';
 import type { FromSchema } from 'json-schema-to-ts';
 import type { JSONSchema } from 'json-schema-to-ts';
 import React from 'react';
@@ -76,8 +75,8 @@ export interface ContextDefinition {
 }
 
 interface FunctionResponse {
-  content?: Serializable;
-  data?: Serializable;
+  content?: any;
+  data?: any;
 }
 
 interface FunctionOptions<TParameters extends CompatibleJSONSchema = CompatibleJSONSchema> {

--- a/x-pack/plugins/observability_ai_assistant/public/application.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/application.tsx
@@ -6,12 +6,13 @@
  */
 import { EuiErrorBoundary } from '@elastic/eui';
 import type { CoreStart, CoreTheme } from '@kbn/core/public';
-import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { RouteRenderer, RouterProvider } from '@kbn/typed-react-router-config';
 import type { History } from 'history';
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { Observable } from 'rxjs';
+import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { ObservabilityAIAssistantProvider } from './context/observability_ai_assistant_provider';
 import { observabilityAIAssistantRouter } from './routes/config';
 import type {
@@ -32,9 +33,12 @@ export function Application({
   pluginsStart: ObservabilityAIAssistantPluginStartDependencies;
   service: ObservabilityAIAssistantService;
 }) {
+  const theme = useMemo(() => {
+    return { theme$ };
+  }, [theme$]);
   return (
     <EuiErrorBoundary>
-      <KibanaThemeProvider theme$={theme$}>
+      <KibanaThemeProvider theme={theme}>
         <KibanaContextProvider
           services={{
             ...coreStart,

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -7,6 +7,8 @@
 import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
+import { ObservabilityAIAssistantChatServiceProvider } from '../../context/observability_ai_assistant_chat_service_provider';
+import { useAbortableAsync } from '../../hooks/use_abortable_async';
 import { useConversation } from '../../hooks/use_conversation';
 import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
 import { EMPTY_CONVERSATION_TITLE } from '../../i18n';
@@ -16,12 +18,23 @@ import { ChatFlyout } from '../chat/chat_flyout';
 export function ObservabilityAIAssistantActionMenuItem() {
   const service = useObservabilityAIAssistant();
 
+  const [isOpen, setIsOpen] = useState(false);
+
+  const chatService = useAbortableAsync(
+    ({ signal }) => {
+      if (!isOpen) {
+        return Promise.resolve(undefined);
+      }
+      return service.start({ signal });
+    },
+    [service, isOpen]
+  );
+
   const [conversationId, setConversationId] = useState<string>();
 
-  const { conversation, displayedMessages, setDisplayedMessages, save } =
-    useConversation(conversationId);
-
-  const [isOpen, setIsOpen] = useState(false);
+  const { conversation, displayedMessages, setDisplayedMessages, save } = useConversation({
+    conversationId,
+  });
 
   if (!service.isEnabled()) {
     return null;
@@ -46,25 +59,29 @@ export function ObservabilityAIAssistantActionMenuItem() {
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiHeaderLink>
-      <ChatFlyout
-        isOpen={isOpen}
-        title={conversation.value?.conversation.title ?? EMPTY_CONVERSATION_TITLE}
-        messages={displayedMessages}
-        conversationId={conversationId}
-        onClose={() => {
-          setIsOpen(() => false);
-        }}
-        onChatComplete={(messages) => {
-          save(messages)
-            .then((nextConversation) => {
-              setConversationId(nextConversation.conversation.id);
-            })
-            .catch(() => {});
-        }}
-        onChatUpdate={(nextMessages) => {
-          setDisplayedMessages(nextMessages);
-        }}
-      />
+      {chatService.value ? (
+        <ObservabilityAIAssistantChatServiceProvider value={chatService.value}>
+          <ChatFlyout
+            isOpen={isOpen}
+            title={conversation.value?.conversation.title ?? EMPTY_CONVERSATION_TITLE}
+            messages={displayedMessages}
+            conversationId={conversationId}
+            onClose={() => {
+              setIsOpen(() => false);
+            }}
+            onChatComplete={(messages) => {
+              save(messages)
+                .then((nextConversation) => {
+                  setConversationId(nextConversation.conversation.id);
+                })
+                .catch(() => {});
+            }}
+            onChatUpdate={(nextMessages) => {
+              setDisplayedMessages(nextMessages);
+            }}
+          />
+        </ObservabilityAIAssistantChatServiceProvider>
+      ) : null}
     </>
   );
 }

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.stories.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.stories.tsx
@@ -23,7 +23,7 @@ const defaultProps: ComponentStoryObj<typeof Component> = {
   args: {
     title: 'My Conversation',
     messages: [
-      getAssistantSetupMessage(),
+      getAssistantSetupMessage({ contexts: [] }),
       {
         '@timestamp': new Date().toISOString(),
         message: {

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.stories.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.stories.tsx
@@ -7,10 +7,8 @@
 
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import React from 'react';
-import { Observable } from 'rxjs';
 import { MessageRole } from '../../../common';
 import { getAssistantSetupMessage } from '../../service/get_assistant_setup_message';
-import { ObservabilityAIAssistantService } from '../../types';
 import { KibanaReactStorybookDecorator } from '../../utils/storybook_decorator';
 import { ChatBody as Component } from './chat_body';
 
@@ -66,11 +64,6 @@ const defaultProps: ComponentStoryObj<typeof Component> = {
     currentUser: {
       username: 'elastic',
     },
-    service: {
-      chat: () => {
-        return new Observable();
-      },
-    } as unknown as ObservabilityAIAssistantService,
     onChatUpdate: () => {},
     onChatComplete: () => {},
   },

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import React from 'react';
-import { css } from '@emotion/css';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -15,12 +13,14 @@ import {
   EuiPanel,
   EuiSpacer,
 } from '@elastic/eui';
+import { css } from '@emotion/css';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
+import React from 'react';
 import type { Message } from '../../../common/types';
 import type { UseGenAIConnectorsResult } from '../../hooks/use_genai_connectors';
-import { UseKnowledgeBaseResult } from '../../hooks/use_knowledge_base';
+import type { UseKnowledgeBaseResult } from '../../hooks/use_knowledge_base';
 import { useTimeline } from '../../hooks/use_timeline';
-import { ObservabilityAIAssistantService } from '../../types';
+import { useObservabilityAIAssistantChatService } from '../../hooks/use_observability_ai_assistant_chat_service';
 import { MissingCredentialsCallout } from '../missing_credentials_callout';
 import { ChatHeader } from './chat_header';
 import { ChatPromptEditor } from './chat_prompt_editor';
@@ -46,7 +46,6 @@ export function ChatBody({
   connectors,
   knowledgeBase,
   currentUser,
-  service,
   connectorsManagementHref,
   onChatUpdate,
   onChatComplete,
@@ -56,19 +55,19 @@ export function ChatBody({
   connectors: UseGenAIConnectorsResult;
   knowledgeBase: UseKnowledgeBaseResult;
   currentUser?: Pick<AuthenticatedUser, 'full_name' | 'username'>;
-  service: ObservabilityAIAssistantService;
   connectorsManagementHref: string;
   onChatUpdate: (messages: Message[]) => void;
   onChatComplete: (messages: Message[]) => void;
 }) {
+  const chatService = useObservabilityAIAssistantChatService();
+
   const timeline = useTimeline({
     messages,
     connectors,
     currentUser,
-    service,
+    chatService,
     onChatUpdate,
     onChatComplete,
-    knowledgeBaseAvailable: !!knowledgeBase.status.value?.ready,
   });
 
   let footer: React.ReactNode;

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_flyout.stories.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_flyout.stories.tsx
@@ -30,7 +30,7 @@ const Template: ComponentStory<typeof Component> = (props: ChatFlyoutProps) => {
 const defaultProps: ChatFlyoutProps = {
   isOpen: true,
   title: 'How is this working',
-  messages: [getAssistantSetupMessage()],
+  messages: [getAssistantSetupMessage({ contexts: [] })],
   onClose: () => {},
 };
 

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_flyout.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_flyout.tsx
@@ -6,22 +6,23 @@
  */
 import { EuiFlexGroup, EuiFlexItem, EuiFlyout, EuiLink, EuiPanel, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/css';
-import React, { useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
+import React, { useEffect } from 'react';
 import type { Message } from '../../../common/types';
 import { useCurrentUser } from '../../hooks/use_current_user';
 import { useGenAIConnectors } from '../../hooks/use_genai_connectors';
 import { useKibana } from '../../hooks/use_kibana';
-import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
+import { useKnowledgeBase } from '../../hooks/use_knowledge_base';
 import { useObservabilityAIAssistantRouter } from '../../hooks/use_observability_ai_assistant_router';
 import { getConnectorsManagementHref } from '../../utils/get_connectors_management_href';
 import { ChatBody } from './chat_body';
-import { useKnowledgeBase } from '../../hooks/use_knowledge_base';
-import { useAbortableAsync } from '../../hooks/use_abortable_async';
-import { ObservabilityAIAssistantChatServiceProvider } from '../../context/observability_ai_assistant_chat_service_provider';
 
 const containerClassName = css`
   max-height: 100%;
+`;
+
+const bodyClassName = css`
+  overflow-y: auto;
 `;
 
 export function ChatFlyout({
@@ -48,15 +49,6 @@ export function ChatFlyout({
   const {
     services: { http },
   } = useKibana();
-
-  const service = useObservabilityAIAssistant();
-
-  const chatService = useAbortableAsync(
-    ({ signal }) => {
-      return service.start({ signal });
-    },
-    [service]
-  );
 
   const { euiTheme } = useEuiTheme();
 
@@ -100,29 +92,25 @@ export function ChatFlyout({
             )}
           </EuiPanel>
         </EuiFlexItem>
-        <EuiFlexItem>
-          {chatService.value ? (
-            <ObservabilityAIAssistantChatServiceProvider value={chatService.value}>
-              <ChatBody
-                connectors={connectors}
-                title={title}
-                messages={messages}
-                currentUser={currentUser}
-                connectorsManagementHref={getConnectorsManagementHref(http)}
-                knowledgeBase={knowledgeBase}
-                onChatUpdate={(nextMessages) => {
-                  if (onChatUpdate) {
-                    onChatUpdate(nextMessages);
-                  }
-                }}
-                onChatComplete={(nextMessages) => {
-                  if (onChatComplete) {
-                    onChatComplete(nextMessages);
-                  }
-                }}
-              />
-            </ObservabilityAIAssistantChatServiceProvider>
-          ) : null}
+        <EuiFlexItem grow className={bodyClassName}>
+          <ChatBody
+            connectors={connectors}
+            title={title}
+            messages={messages}
+            currentUser={currentUser}
+            connectorsManagementHref={getConnectorsManagementHref(http)}
+            knowledgeBase={knowledgeBase}
+            onChatUpdate={(nextMessages) => {
+              if (onChatUpdate) {
+                onChatUpdate(nextMessages);
+              }
+            }}
+            onChatComplete={(nextMessages) => {
+              if (onChatComplete) {
+                onChatComplete(nextMessages);
+              }
+            }}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlyout>

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_prompt_editor.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_prompt_editor.tsx
@@ -5,22 +5,21 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  EuiButtonIcon,
   EuiButtonEmpty,
-  EuiTextArea,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
   EuiPanel,
+  EuiSpacer,
+  EuiTextArea,
   keys,
 } from '@elastic/eui';
-import { CodeEditor } from '@kbn/kibana-react-plugin/public';
 import { i18n } from '@kbn/i18n';
-import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
+import { CodeEditor } from '@kbn/kibana-react-plugin/public';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { MessageRole, type Message } from '../../../common';
 import { useJsonEditorModel } from '../../hooks/use_json_editor_model';
-import { type Message, MessageRole } from '../../../common';
 import { FunctionListPopover } from './function_list_popover';
 
 export interface ChatPromptEditorProps {
@@ -40,9 +39,6 @@ export function ChatPromptEditor({
   initialFunctionPayload,
   onSubmit,
 }: ChatPromptEditorProps) {
-  const { getFunctions } = useObservabilityAIAssistant();
-  const functions = getFunctions();
-
   const [prompt, setPrompt] = useState(initialPrompt);
 
   const [selectedFunctionName, setSelectedFunctionName] = useState<string | undefined>(
@@ -159,7 +155,6 @@ export function ChatPromptEditor({
             <EuiFlexGroup responsive={false}>
               <EuiFlexItem grow>
                 <FunctionListPopover
-                  functions={functions}
                   selectedFunctionName={selectedFunctionName}
                   onSelectFunction={handleSelectFunction}
                 />

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_timeline.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_timeline.tsx
@@ -9,12 +9,12 @@ import { EuiCommentList } from '@elastic/eui';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 import React from 'react';
 import { type Message } from '../../../common';
+
 import type { Feedback } from '../feedback_buttons';
 import { ChatItem } from './chat_item';
 
 export interface ChatTimelineItem
-  extends Pick<Message, '@timestamp'>,
-    Pick<Message['message'], 'role' | 'content' | 'function_call'> {
+  extends Pick<Message['message'], 'role' | 'content' | 'function_call'> {
   id: string;
   title: string;
   loading: boolean;

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.stories.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.stories.tsx
@@ -23,7 +23,6 @@ const Template: ComponentStory<typeof Component> = (props: FunctionListPopover) 
 };
 
 const defaultProps: FunctionListPopover = {
-  functions: [],
   onSelectFunction: () => {},
 };
 

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.tsx
@@ -16,16 +16,17 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FunctionDefinition } from '../../../common/types';
+import { useObservabilityAIAssistantChatService } from '../../hooks/use_observability_ai_assistant_chat_service';
 
 export function FunctionListPopover({
-  functions,
   selectedFunctionName,
   onSelectFunction,
 }: {
-  functions: FunctionDefinition[];
   selectedFunctionName?: string;
   onSelectFunction: (func: string) => void;
 }) {
+  const chatService = useObservabilityAIAssistantChatService();
+
   const [isFunctionListOpen, setIsFunctionListOpen] = useState(false);
 
   const handleClickFunctionList = () => {
@@ -80,7 +81,7 @@ export function FunctionListPopover({
             {
               id: 0,
               width: 500,
-              items: functions.map((func) => ({
+              items: chatService.getFunctions().map((func) => ({
                 name: (
                   <>
                     <EuiText size="s">

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/knowledge_base_callout.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/knowledge_base_callout.tsx
@@ -30,7 +30,7 @@ export function KnowledgeBaseCallout({ knowledgeBase }: { knowledgeBase: UseKnow
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued">
-            {i18n.translate('xpack.observabilityAIAssistant.checkingKbAvailability', {
+            {i18n.translate('xpack.observabilityAiAssistant.checkingKbAvailability', {
               defaultMessage: 'Checking availability of knowledge base',
             })}
           </EuiText>
@@ -50,7 +50,7 @@ export function KnowledgeBaseCallout({ knowledgeBase }: { knowledgeBase: UseKnow
     color = 'plain';
     content = (
       <EuiText size="xs" color="subdued">
-        {i18n.translate('xpack.observabilityAIAssistant.poweredByModel', {
+        {i18n.translate('xpack.observabilityAiAssistant.poweredByModel', {
           defaultMessage: 'Powered by {model}',
           values: {
             model: 'ELSER',
@@ -67,7 +67,7 @@ export function KnowledgeBaseCallout({ knowledgeBase }: { knowledgeBase: UseKnow
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color={color}>
-            {i18n.translate('xpack.observabilityAIAssistant.installingKb', {
+            {i18n.translate('xpack.observabilityAiAssistant.installingKb', {
               defaultMessage: 'Setting up the knowledge base',
             })}
           </EuiText>
@@ -78,7 +78,7 @@ export function KnowledgeBaseCallout({ knowledgeBase }: { knowledgeBase: UseKnow
     color = 'danger';
     content = (
       <EuiText size="xs" color={color}>
-        {i18n.translate('xpack.observabilityAIAssistant.failedToSetupKnowledgeBase', {
+        {i18n.translate('xpack.observabilityAiAssistant.failedToSetupKnowledgeBase', {
           defaultMessage: 'Failed to set up knowledge base.',
         })}
       </EuiText>
@@ -91,7 +91,7 @@ export function KnowledgeBaseCallout({ knowledgeBase }: { knowledgeBase: UseKnow
         }}
       >
         <EuiText size="xs">
-          {i18n.translate('xpack.observabilityAIAssistant.setupKb', {
+          {i18n.translate('xpack.observabilityAiAssistant.setupKb', {
             defaultMessage: 'Improve your experience by setting up the knowledge base.',
           })}
         </EuiText>

--- a/x-pack/plugins/observability_ai_assistant/public/components/insight/insight.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/insight/insight.tsx
@@ -11,7 +11,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Subscription } from 'rxjs';
 import { MessageRole, type Message } from '../../../common/types';
 import { useGenAIConnectors } from '../../hooks/use_genai_connectors';
-import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
 import type { PendingMessage } from '../../types';
 import { ChatFlyout } from '../chat/chat_flyout';
 import { ConnectorSelectorBase } from '../connector_selector/connector_selector_base';
@@ -23,6 +22,7 @@ import { StopGeneratingButton } from '../buttons/stop_generating_button';
 import { InsightBase } from './insight_base';
 import { MissingCredentialsCallout } from '../missing_credentials_callout';
 import { getConnectorsManagementHref } from '../../utils/get_connectors_management_href';
+import { useObservabilityAIAssistantChatService } from '../../hooks/use_observability_ai_assistant_chat_service';
 
 function ChatContent({
   title,
@@ -33,7 +33,7 @@ function ChatContent({
   messages: Message[];
   connectorId: string;
 }) {
-  const service = useObservabilityAIAssistant();
+  const chatService = useObservabilityAIAssistantChatService();
 
   const [pendingMessage, setPendingMessage] = useState<PendingMessage | undefined>();
   const [loading, setLoading] = useState(false);
@@ -42,19 +42,17 @@ function ChatContent({
   const reloadReply = useCallback(() => {
     setLoading(true);
 
-    const nextSubscription = service
-      .chat({ messages, connectorId, knowledgeBaseAvailable: false })
-      .subscribe({
-        next: (msg) => {
-          setPendingMessage(() => msg);
-        },
-        complete: () => {
-          setLoading(false);
-        },
-      });
+    const nextSubscription = chatService.chat({ messages, connectorId }).subscribe({
+      next: (msg) => {
+        setPendingMessage(() => msg);
+      },
+      complete: () => {
+        setLoading(false);
+      },
+    });
 
     setSubscription(nextSubscription);
-  }, [messages, connectorId, service]);
+  }, [messages, connectorId, chatService]);
 
   useEffect(() => {
     reloadReply();

--- a/x-pack/plugins/observability_ai_assistant/public/components/render_function.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/render_function.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { useObservabilityAIAssistant } from '../hooks/use_observability_ai_assistant';
+import { useObservabilityAIAssistantChatService } from '../hooks/use_observability_ai_assistant_chat_service';
 
 interface Props {
   name: string;
@@ -14,7 +14,6 @@ interface Props {
 }
 
 export function RenderFunction(props: Props) {
-  const service = useObservabilityAIAssistant();
-
-  return <>{service.renderFunction(props.name, props.arguments, props.response)}</>;
+  const chatService = useObservabilityAIAssistantChatService();
+  return <>{chatService.renderFunction(props.name, props.arguments, props.response)}</>;
 }

--- a/x-pack/plugins/observability_ai_assistant/public/components/render_function.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/render_function.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 import React from 'react';
+import { Message } from '../../common';
 import { useObservabilityAIAssistantChatService } from '../hooks/use_observability_ai_assistant_chat_service';
 
 interface Props {
   name: string;
   arguments: string | undefined;
-  response: { content?: string; data?: string };
+  response: Message['message'];
 }
 
 export function RenderFunction(props: Props) {

--- a/x-pack/plugins/observability_ai_assistant/public/context/observability_ai_assistant_chat_service_provider.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/context/observability_ai_assistant_chat_service_provider.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext } from 'react';
+import type { ObservabilityAIAssistantChatService } from '../types';
+
+export const ObservabilityAIAssistantChatServiceContext = createContext<
+  ObservabilityAIAssistantChatService | undefined
+>(undefined);
+
+export const ObservabilityAIAssistantChatServiceProvider =
+  ObservabilityAIAssistantChatServiceContext.Provider;

--- a/x-pack/plugins/observability_ai_assistant/public/functions/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/functions/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import dedent from 'dedent';
 import type { RegisterContextDefinition, RegisterFunctionDefinition } from '../../common/types';
 import type { ObservabilityAIAssistantPluginStartDependencies } from '../types';
 import type { ObservabilityAIAssistantService } from '../types';
@@ -12,24 +13,60 @@ import { registerElasticsearchFunction } from './elasticsearch';
 import { registerRecallFunction } from './recall';
 import { registerSummarisationFunction } from './summarise';
 
-export function registerFunctions({
+export async function registerFunctions({
   registerFunction,
   registerContext,
   service,
   pluginsStart,
+  signal,
 }: {
   registerFunction: RegisterFunctionDefinition;
   registerContext: RegisterContextDefinition;
   service: ObservabilityAIAssistantService;
   pluginsStart: ObservabilityAIAssistantPluginStartDependencies;
+  signal: AbortSignal;
 }) {
-  registerContext({
-    name: 'core',
-    description:
-      'Core functions, like calling Elasticsearch APIs, storing embeddables for instructions or creating base visualisations.',
-  });
+  return service
+    .callApi('GET /internal/observability_ai_assistant/functions/kb_status', {
+      signal,
+    })
+    .then((response) => {
+      const isReady = response.ready;
 
-  registerElasticsearchFunction({ service, registerFunction });
-  registerSummarisationFunction({ service, registerFunction });
-  registerRecallFunction({ service, registerFunction });
+      let description = `You have the ability to call Elasticsearch APIs or create visualisations using Lens.`;
+
+      if (isReady) {
+        description += `You can use the "summarise" functions to store new information you have learned in a knowledge database. Once you have established that you did not know the answer to a question, and the user gave you this information, it's important that you create a summarisation of what you have learned and store it in the knowledge database. When you create this summarisation, make sure you craft it in a way that can be recalled with a semantic search later.
+
+        Additionally, you can use the "recall" function to retrieve relevant information from the knowledge database. Using the "recall" function will allow you to create a much more tailored and improved user experience. Assume the user has told you before.
+      
+        For every question that the user asks, you, as the assistant, must query the knowledge base, no matter how confident you are in your response.
+      
+        When the user starts a conversation, you as the assistant, MUST ALWAYS use the "recall" function to make sure you have enough context from the knowledge database to understand their question. DO NOT assume your knowledge is sufficient to answer the question appropriately. Make sure you mention this to the user in your first reply to them.
+      
+        You do have access to private data that the user has shared with you in previous conversations.
+      
+        Given this ability to store and recall data, it is very important to not make assumptions about the user's data or preferences, but rather, first query the knowledge database, and if nothing relevant comes up, ask the user for clarification. This is very important! They could be storing their data in any field, and in any data stream or index.
+      
+        RIGHT:
+        User: "What is NASA"
+        Assistant executes recall function
+        Assistant answers question with data from recall function response
+      
+        WRONG:
+        User: "What is NASA"
+        Assistant answers question without querying the knowledge`;
+        registerSummarisationFunction({ service, registerFunction });
+        registerRecallFunction({ service, registerFunction });
+      } else {
+        description += `You do not have a working memory. Don't try to recall information via other functions.  If the user expects you to remember the previous conversations, tell them they can set up the knowledge base. A banner is available at the top of the conversation to set this up.`;
+      }
+
+      registerElasticsearchFunction({ service, registerFunction });
+
+      registerContext({
+        name: 'core',
+        description: dedent(description),
+      });
+    });
 }

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/__storybook_mocks__/use_observability_ai_assistant copy.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/__storybook_mocks__/use_observability_ai_assistant copy.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-const service = {
-  start: async () => {
-    return {
-      getFunctions: [],
-    };
-  },
-};
-
-export function useObservabilityAIAssistant() {
-  return service;
+export function useObservabilityAIAssistantChatService() {
+  return {
+    getFunctions: () => {
+      return [];
+    },
+  };
 }

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_conversation.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_conversation.ts
@@ -9,12 +9,19 @@ import { merge, omit } from 'lodash';
 import { Dispatch, SetStateAction, useState } from 'react';
 import type { Conversation, Message } from '../../common';
 import type { ConversationCreateRequest } from '../../common/types';
+import { ObservabilityAIAssistantChatService } from '../types';
 import { useAbortableAsync, type AbortableAsyncState } from './use_abortable_async';
 import { useKibana } from './use_kibana';
 import { useObservabilityAIAssistant } from './use_observability_ai_assistant';
 import { createNewConversation } from './use_timeline';
 
-export function useConversation(conversationId?: string): {
+export function useConversation({
+  conversationId,
+  chatService,
+}: {
+  conversationId?: string;
+  chatService?: ObservabilityAIAssistantChatService;
+}): {
   conversation: AbortableAsyncState<ConversationCreateRequest | Conversation | undefined>;
   displayedMessages: Message[];
   setDisplayedMessages: Dispatch<SetStateAction<Message[]>>;
@@ -32,7 +39,9 @@ export function useConversation(conversationId?: string): {
     useAbortableAsync(
       ({ signal }) => {
         if (!conversationId) {
-          const nextConversation = createNewConversation();
+          const nextConversation = createNewConversation({
+            contexts: chatService?.getContexts() || [],
+          });
           setDisplayedMessages(nextConversation.messages);
           return nextConversation;
         }
@@ -51,7 +60,7 @@ export function useConversation(conversationId?: string): {
             throw error;
           });
       },
-      [conversationId]
+      [conversationId, chatService]
     );
 
   return {

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_json_editor_model.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_json_editor_model.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useMemo } from 'react';
 import { monaco } from '@kbn/monaco';
-import { useObservabilityAIAssistant } from './use_observability_ai_assistant';
+import { useMemo } from 'react';
 import { createInitializedObject } from '../utils/create_initialized_object';
+import { useObservabilityAIAssistantChatService } from './use_observability_ai_assistant_chat_service';
 
 const { editor, languages, Uri } = monaco;
 
@@ -21,10 +21,11 @@ export const useJsonEditorModel = ({
   functionName: string | undefined;
   initialJson?: string | undefined;
 }) => {
-  const { getFunctions } = useObservabilityAIAssistant();
-  const functions = getFunctions();
+  const chatService = useObservabilityAIAssistantChatService();
 
-  const functionDefinition = functions.find((func) => func.options.name === functionName);
+  const functionDefinition = chatService
+    .getFunctions()
+    .find((func) => func.options.name === functionName);
 
   return useMemo(() => {
     if (!functionDefinition) {

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_observability_ai_assistant_chat_service.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_observability_ai_assistant_chat_service.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useContext } from 'react';
+import { ObservabilityAIAssistantChatServiceContext } from '../context/observability_ai_assistant_chat_service_provider';
+
+export function useObservabilityAIAssistantChatService() {
+  const services = useContext(ObservabilityAIAssistantChatServiceContext);
+
+  if (!services) {
+    throw new Error(
+      'ObservabilityAIAssistantChatServiceContext not set. Did you wrap your component in `<ObservabilityAIAssistantChatServiceProvider/>`?'
+    );
+  }
+
+  return services;
+}

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_timeline.test.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_timeline.test.ts
@@ -34,7 +34,7 @@ describe('useTimeline', () => {
             selectConnector: () => {},
             connectors: [{ id: 'OpenAI' }] as FindActionResult[],
           },
-          service: {},
+          chatService: {},
           messages: [],
           onChatComplete: jest.fn(),
           onChatUpdate: jest.fn(),
@@ -65,14 +65,12 @@ describe('useTimeline', () => {
         initialProps: {
           messages: [
             {
-              '@timestamp': new Date().toISOString(),
               message: {
                 role: MessageRole.User,
                 content: 'Hello',
               },
             },
             {
-              '@timestamp': new Date().toISOString(),
               message: {
                 role: MessageRole.Assistant,
                 content: 'Goodbye',
@@ -82,7 +80,7 @@ describe('useTimeline', () => {
           connectors: {
             selectedConnector: 'foo',
           },
-          service: {
+          chatService: {
             chat: () => {},
           },
         } as unknown as HookProps,
@@ -124,11 +122,11 @@ describe('useTimeline', () => {
   describe('when submitting a new prompt', () => {
     let subject: Subject<PendingMessage>;
 
-    let props: Omit<HookProps, 'onChatUpdate' | 'onChatComplete' | 'service'> & {
+    let props: Omit<HookProps, 'onChatUpdate' | 'onChatComplete' | 'chatService'> & {
       onChatUpdate: jest.MockedFn<HookProps['onChatUpdate']>;
       onChatComplete: jest.MockedFn<HookProps['onChatComplete']>;
-      service: Omit<HookProps['service'], 'executeFunction'> & {
-        executeFunction: jest.MockedFn<HookProps['service']['executeFunction']>;
+      chatService: Omit<HookProps['chatService'], 'executeFunction'> & {
+        executeFunction: jest.MockedFn<HookProps['chatService']['executeFunction']>;
       };
     };
 
@@ -138,7 +136,7 @@ describe('useTimeline', () => {
         connectors: {
           selectedConnector: 'foo',
         },
-        service: {
+        chatService: {
           chat: jest.fn().mockImplementation(() => {
             subject = new BehaviorSubject<PendingMessage>({
               message: {
@@ -361,7 +359,7 @@ describe('useTimeline', () => {
             subject.complete();
           });
 
-          props.service.executeFunction.mockResolvedValueOnce({
+          props.chatService.executeFunction.mockResolvedValueOnce({
             content: {
               message: 'my-response',
             },
@@ -385,7 +383,7 @@ describe('useTimeline', () => {
 
           expect(props.onChatComplete).not.toHaveBeenCalled();
 
-          expect(props.service.executeFunction).toHaveBeenCalledWith(
+          expect(props.chatService.executeFunction).toHaveBeenCalledWith(
             'my_function',
             '{}',
             expect.any(Object)

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_timeline.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_timeline.ts
@@ -9,7 +9,12 @@ import { AbortError } from '@kbn/kibana-utils-plugin/common';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Subscription } from 'rxjs';
-import { MessageRole, type ConversationCreateRequest, type Message } from '../../common/types';
+import {
+  ContextDefinition,
+  MessageRole,
+  type ConversationCreateRequest,
+  type Message,
+} from '../../common/types';
 import type { ChatPromptEditorProps } from '../components/chat/chat_prompt_editor';
 import type { ChatTimelineProps } from '../components/chat/chat_timeline';
 import { EMPTY_CONVERSATION_TITLE } from '../i18n';
@@ -18,10 +23,14 @@ import type { ObservabilityAIAssistantChatService, PendingMessage } from '../typ
 import { getTimelineItemsfromConversation } from '../utils/get_timeline_items_from_conversation';
 import type { UseGenAIConnectorsResult } from './use_genai_connectors';
 
-export function createNewConversation(): ConversationCreateRequest {
+export function createNewConversation({
+  contexts,
+}: {
+  contexts: ContextDefinition[];
+}): ConversationCreateRequest {
   return {
     '@timestamp': new Date().toISOString(),
-    messages: [getAssistantSetupMessage()],
+    messages: [getAssistantSetupMessage({ contexts })],
     conversation: {
       title: EMPTY_CONVERSATION_TITLE,
     },
@@ -198,8 +207,8 @@ export function useTimeline({
   return {
     items,
     onEdit: async (item, newMessage) => {
-      const index = items.indexOf(item);
-      const sliced = messages.slice(0, index);
+      const indexOf = items.indexOf(item);
+      const sliced = messages.slice(0, indexOf - 1);
       const nextMessages = await chat(sliced.concat(newMessage));
       onChatComplete(nextMessages);
     },

--- a/x-pack/plugins/observability_ai_assistant/public/plugin.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/plugin.tsx
@@ -17,13 +17,6 @@ import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import type {
-  ContextDefinition,
-  ContextRegistry,
-  FunctionRegistry,
-  RegisterContextDefinition,
-  RegisterFunctionDefinition,
-} from '../common/types';
 import { registerFunctions } from './functions';
 import { createService } from './service/create_service';
 import type {
@@ -102,36 +95,22 @@ export class ObservabilityAIAssistantPlugin
     coreStart: CoreStart,
     pluginsStart: ObservabilityAIAssistantPluginStartDependencies
   ): ObservabilityAIAssistantPluginStart {
-    const contextRegistry: ContextRegistry = new Map();
-    const functionRegistry: FunctionRegistry = new Map();
-
     const service = (this.service = createService({
       coreStart,
       securityStart: pluginsStart.security,
-      contextRegistry,
-      functionRegistry,
       enabled: coreStart.application.capabilities.observabilityAIAssistant.show === true,
     }));
 
-    const registerContext: RegisterContextDefinition = (context: ContextDefinition) => {
-      contextRegistry.set(context.name, context);
-    };
-
-    const registerFunction: RegisterFunctionDefinition = (def, respond, render) => {
-      functionRegistry.set(def.name, { options: def, respond, render });
-    };
-
-    registerFunctions({
-      registerContext,
-      registerFunction,
-      service,
-      pluginsStart,
+    service.register(({ signal, registerContext, registerFunction }) => {
+      return registerFunctions({
+        service,
+        signal,
+        pluginsStart,
+        registerContext,
+        registerFunction,
+      });
     });
 
-    return {
-      ...service,
-      registerContext,
-      registerFunction,
-    };
+    return service;
   }
 }

--- a/x-pack/plugins/observability_ai_assistant/public/routes/conversations/conversation_view.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/routes/conversations/conversation_view.tsx
@@ -63,23 +63,25 @@ export function ConversationView() {
 
   const [isUpdatingList, setIsUpdatingList] = useState(false);
 
+  const chatService = useAbortableAsync(
+    ({ signal }) => {
+      return service.start({ signal });
+    },
+    [service]
+  );
+
   const conversationId = 'conversationId' in path ? path.conversationId : undefined;
 
-  const { conversation, displayedMessages, setDisplayedMessages, save } =
-    useConversation(conversationId);
+  const { conversation, displayedMessages, setDisplayedMessages, save } = useConversation({
+    conversationId,
+    chatService: chatService.value,
+  });
 
   const conversations = useAbortableAsync(
     ({ signal }) => {
       return service.callApi('POST /internal/observability_ai_assistant/conversations', {
         signal,
       });
-    },
-    [service]
-  );
-
-  const chatService = useAbortableAsync(
-    ({ signal }) => {
-      return service.start({ signal });
     },
     [service]
   );

--- a/x-pack/plugins/observability_ai_assistant/public/service/create_chat_service.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/service/create_chat_service.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IncomingMessage } from 'http';
+import { cloneDeep, pick } from 'lodash';
+import {
+  BehaviorSubject,
+  map,
+  filter as rxJsFilter,
+  scan,
+  catchError,
+  of,
+  concatMap,
+  shareReplay,
+  finalize,
+  delay,
+} from 'rxjs';
+import { HttpResponse } from '@kbn/core/public';
+import { AbortError } from '@kbn/kibana-utils-plugin/common';
+import {
+  type RegisterContextDefinition,
+  type RegisterFunctionDefinition,
+  Message,
+  MessageRole,
+  ContextRegistry,
+  FunctionRegistry,
+} from '../../common/types';
+import { ObservabilityAIAssistantAPIClient } from '../api';
+import type {
+  ChatRegistrationFunction,
+  CreateChatCompletionResponseChunk,
+  ObservabilityAIAssistantChatService,
+  PendingMessage,
+} from '../types';
+import { readableStreamReaderIntoObservable } from '../utils/readable_stream_reader_into_observable';
+
+export async function createChatService({
+  signal: setupAbortSignal,
+  registrations,
+  client,
+}: {
+  signal: AbortSignal;
+  registrations: ChatRegistrationFunction[];
+  client: ObservabilityAIAssistantAPIClient;
+}): Promise<ObservabilityAIAssistantChatService> {
+  const contextRegistry: ContextRegistry = new Map();
+  const functionRegistry: FunctionRegistry = new Map();
+
+  const registerContext: RegisterContextDefinition = (context) => {
+    contextRegistry.set(context.name, context);
+  };
+
+  const registerFunction: RegisterFunctionDefinition = (def, respond, render) => {
+    functionRegistry.set(def.name, { options: def, respond, render });
+  };
+
+  const getContexts: ObservabilityAIAssistantChatService['getContexts'] = () => {
+    return Array.from(contextRegistry.values());
+  };
+  const getFunctions: ObservabilityAIAssistantChatService['getFunctions'] = ({
+    contexts,
+    filter,
+  } = {}) => {
+    const allFunctions = Array.from(functionRegistry.values());
+
+    return contexts || filter
+      ? allFunctions.filter((fn) => {
+          const matchesContext =
+            !contexts || fn.options.contexts.some((context) => contexts.includes(context));
+          const matchesFilter =
+            !filter || fn.options.name.includes(filter) || fn.options.description.includes(filter);
+
+          return matchesContext && matchesFilter;
+        })
+      : allFunctions;
+  };
+
+  await Promise.all(
+    registrations.map((fn) => fn({ signal: setupAbortSignal, registerContext, registerFunction }))
+  );
+
+  return {
+    executeFunction: async (name, args, signal) => {
+      const fn = functionRegistry.get(name);
+
+      if (!fn) {
+        throw new Error(`Function ${name} not found`);
+      }
+
+      const parsedArguments = args ? JSON.parse(args) : {};
+
+      // validate
+
+      return await fn.respond({ arguments: parsedArguments }, signal);
+    },
+    renderFunction: (name, args, response) => {
+      const fn = functionRegistry.get(name);
+
+      if (!fn) {
+        throw new Error(`Function ${name} not found`);
+      }
+
+      const parsedArguments = args ? JSON.parse(args) : {};
+
+      // validate
+
+      return fn.render?.({ response, arguments: parsedArguments });
+    },
+    getContexts,
+    getFunctions,
+    chat({ connectorId, messages }: { connectorId: string; messages: Message[] }) {
+      const subject = new BehaviorSubject<PendingMessage>({
+        message: {
+          role: MessageRole.Assistant,
+        },
+      });
+
+      const contexts = ['core', 'apm'];
+
+      const functions = getFunctions({ contexts });
+
+      const controller = new AbortController();
+
+      client('POST /internal/observability_ai_assistant/chat', {
+        params: {
+          body: {
+            messages,
+            connectorId,
+            functions: functions.map((fn) => pick(fn.options, 'name', 'description', 'parameters')),
+          },
+        },
+        signal: controller.signal,
+        asResponse: true,
+        rawResponse: true,
+      })
+        .then((_response) => {
+          const response = _response as unknown as HttpResponse<IncomingMessage>;
+
+          const status = response.response?.status;
+
+          if (!status || status >= 400) {
+            throw new Error(response.response?.statusText || 'Unexpected error');
+          }
+
+          const reader = response.response.body?.getReader();
+
+          if (!reader) {
+            throw new Error('Could not get reader from response');
+          }
+
+          const subscription = readableStreamReaderIntoObservable(reader)
+            .pipe(
+              map((line) => line.substring(6)),
+              rxJsFilter((line) => !!line && line !== '[DONE]'),
+              map((line) => JSON.parse(line) as CreateChatCompletionResponseChunk),
+              rxJsFilter((line) => line.object === 'chat.completion.chunk'),
+              scan(
+                (acc, { choices }) => {
+                  acc.message.content += choices[0].delta.content ?? '';
+                  acc.message.function_call.name += choices[0].delta.function_call?.name ?? '';
+                  acc.message.function_call.arguments +=
+                    choices[0].delta.function_call?.arguments ?? '';
+                  return cloneDeep(acc);
+                },
+                {
+                  message: {
+                    content: '',
+                    function_call: {
+                      name: '',
+                      arguments: '',
+                      trigger: MessageRole.Assistant as const,
+                    },
+                    role: MessageRole.Assistant,
+                  },
+                }
+              ),
+              catchError((error) =>
+                of({
+                  ...subject.value,
+                  error,
+                  aborted: error instanceof AbortError || controller.signal.aborted,
+                })
+              )
+            )
+            .subscribe(subject);
+
+          controller.signal.addEventListener('abort', () => {
+            subscription.unsubscribe();
+            subject.next({
+              ...subject.value,
+              aborted: true,
+            });
+            subject.complete();
+          });
+        })
+        .catch((err) => {
+          subject.next({
+            ...subject.value,
+            aborted: false,
+            error: err,
+          });
+          subject.complete();
+        });
+
+      return subject.pipe(
+        concatMap((value) => of(value).pipe(delay(50))),
+        shareReplay(1),
+        finalize(() => {
+          controller.abort();
+        })
+      );
+    },
+  };
+}

--- a/x-pack/plugins/observability_ai_assistant/public/service/create_chat_service.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/service/create_chat_service.ts
@@ -106,9 +106,14 @@ export async function createChatService({
 
       const parsedArguments = args ? JSON.parse(args) : {};
 
+      const parsedResponse = {
+        content: JSON.parse(response.content ?? '{}'),
+        data: JSON.parse(response.data ?? '{}'),
+      };
+
       // validate
 
-      return fn.render?.({ response, arguments: parsedArguments });
+      return fn.render?.({ response: parsedResponse, arguments: parsedArguments });
     },
     getContexts,
     getFunctions,

--- a/x-pack/plugins/observability_ai_assistant/public/service/create_service.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/service/create_service.ts
@@ -5,216 +5,37 @@
  * 2.0.
  */
 
-import type { CoreStart, HttpResponse } from '@kbn/core/public';
-import { AbortError } from '@kbn/kibana-utils-plugin/common';
+import type { CoreStart } from '@kbn/core/public';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
-import { IncomingMessage } from 'http';
-import { cloneDeep, pick } from 'lodash';
-import {
-  BehaviorSubject,
-  catchError,
-  concatMap,
-  delay,
-  filter as rxJsFilter,
-  finalize,
-  map,
-  of,
-  scan,
-  shareReplay,
-} from 'rxjs';
-import type { Message } from '../../common';
-import { ContextRegistry, FunctionRegistry, MessageRole } from '../../common/types';
 import { createCallObservabilityAIAssistantAPI } from '../api';
-import type {
-  CreateChatCompletionResponseChunk,
-  ObservabilityAIAssistantService,
-  PendingMessage,
-} from '../types';
-import { readableStreamReaderIntoObservable } from '../utils/readable_stream_reader_into_observable';
+import type { ChatRegistrationFunction, ObservabilityAIAssistantService } from '../types';
+import { createChatService } from './create_chat_service';
 
 export function createService({
   coreStart,
   securityStart,
-  functionRegistry,
-  contextRegistry,
   enabled,
 }: {
   coreStart: CoreStart;
   securityStart: SecurityPluginStart;
-  functionRegistry: FunctionRegistry;
-  contextRegistry: ContextRegistry;
   enabled: boolean;
-}): ObservabilityAIAssistantService {
+}): ObservabilityAIAssistantService & { register: (fn: ChatRegistrationFunction) => void } {
   const client = createCallObservabilityAIAssistantAPI(coreStart);
 
-  const getContexts: ObservabilityAIAssistantService['getContexts'] = () => {
-    return Array.from(contextRegistry.values());
-  };
-  const getFunctions: ObservabilityAIAssistantService['getFunctions'] = ({
-    contexts,
-    filter,
-  } = {}) => {
-    const allFunctions = Array.from(functionRegistry.values());
-
-    return contexts || filter
-      ? allFunctions.filter((fn) => {
-          const matchesContext =
-            !contexts || fn.options.contexts.some((context) => contexts.includes(context));
-          const matchesFilter =
-            !filter || fn.options.name.includes(filter) || fn.options.description.includes(filter);
-
-          return matchesContext && matchesFilter;
-        })
-      : allFunctions;
-  };
+  const registrations: ChatRegistrationFunction[] = [];
 
   return {
     isEnabled: () => {
       return enabled;
     },
-    chat({
-      connectorId,
-      messages,
-      knowledgeBaseAvailable,
-    }: {
-      connectorId: string;
-      messages: Message[];
-      knowledgeBaseAvailable: boolean;
-    }) {
-      const subject = new BehaviorSubject<PendingMessage>({
-        message: {
-          role: MessageRole.Assistant,
-        },
-      });
-
-      const contexts = ['core'];
-
-      const functions = getFunctions({ contexts });
-
-      const controller = new AbortController();
-
-      client('POST /internal/observability_ai_assistant/chat', {
-        params: {
-          body: {
-            messages,
-            connectorId,
-            functions: functions
-              .map((fn) => pick(fn.options, 'name', 'description', 'parameters'))
-              .filter((fn) =>
-                knowledgeBaseAvailable ? fn : fn.name !== 'recall' && fn.name !== 'summarise'
-              ),
-          },
-        },
-        signal: controller.signal,
-        asResponse: true,
-        rawResponse: true,
-      })
-        .then((_response) => {
-          const response = _response as unknown as HttpResponse<IncomingMessage>;
-
-          const status = response.response?.status;
-
-          if (!status || status >= 400) {
-            throw new Error(response.response?.statusText || 'Unexpected error');
-          }
-
-          const reader = response.response.body?.getReader();
-
-          if (!reader) {
-            throw new Error('Could not get reader from response');
-          }
-
-          const subscription = readableStreamReaderIntoObservable(reader)
-            .pipe(
-              map((line) => line.substring(6)),
-              rxJsFilter((line) => !!line && line !== '[DONE]'),
-              map((line) => JSON.parse(line) as CreateChatCompletionResponseChunk),
-              rxJsFilter((line) => line.object === 'chat.completion.chunk'),
-              scan(
-                (acc, { choices }) => {
-                  acc.message.content += choices[0].delta.content ?? '';
-                  acc.message.function_call.name += choices[0].delta.function_call?.name ?? '';
-                  acc.message.function_call.arguments +=
-                    choices[0].delta.function_call?.arguments ?? '';
-                  return cloneDeep(acc);
-                },
-                {
-                  message: {
-                    content: '',
-                    function_call: {
-                      name: '',
-                      arguments: '',
-                      trigger: MessageRole.Assistant as const,
-                    },
-                    role: MessageRole.Assistant,
-                  },
-                }
-              ),
-              catchError((error) =>
-                of({
-                  ...subject.value,
-                  error,
-                  aborted: error instanceof AbortError || controller.signal.aborted,
-                })
-              )
-            )
-            .subscribe(subject);
-
-          controller.signal.addEventListener('abort', () => {
-            subscription.unsubscribe();
-            subject.next({
-              ...subject.value,
-              aborted: true,
-            });
-            subject.complete();
-          });
-        })
-        .catch((err) => {
-          subject.next({
-            ...subject.value,
-            aborted: false,
-            error: err,
-          });
-          subject.complete();
-        });
-
-      return subject.pipe(
-        concatMap((value) => of(value).pipe(delay(50))),
-        shareReplay(1),
-        finalize(() => {
-          controller.abort();
-        })
-      );
+    register: (fn) => {
+      registrations.push(fn);
     },
+    start: async ({ signal }) => {
+      return await createChatService({ client, signal, registrations });
+    },
+
     callApi: client,
     getCurrentUser: () => securityStart.authc.getCurrentUser(),
-    getContexts,
-    getFunctions,
-    executeFunction: async (name, args, signal) => {
-      const fn = functionRegistry.get(name);
-
-      if (!fn) {
-        throw new Error(`Function ${name} not found`);
-      }
-
-      const parsedArguments = args ? JSON.parse(args) : {};
-
-      // validate
-
-      return await fn.respond({ arguments: parsedArguments }, signal);
-    },
-    renderFunction: (name, args, response) => {
-      const fn = functionRegistry.get(name);
-
-      if (!fn) {
-        throw new Error(`Function ${name} not found`);
-      }
-
-      const parsedArguments = args ? JSON.parse(args) : {};
-
-      // validate
-
-      return fn.render?.({ response, arguments: parsedArguments });
-    },
   };
 }

--- a/x-pack/plugins/observability_ai_assistant/public/service/get_assistant_setup_message.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/service/get_assistant_setup_message.ts
@@ -7,51 +7,20 @@
 
 import dedent from 'dedent';
 import { MessageRole } from '../../common';
+import { ContextDefinition } from '../../common/types';
 
-export function getAssistantSetupMessage() {
+export function getAssistantSetupMessage({ contexts }: { contexts: ContextDefinition[] }) {
   return {
     '@timestamp': new Date().toISOString(),
     message: {
       role: MessageRole.System as const,
-      content:
-        dedent(`You are a helpful assistant for Elastic Observability. Your goal is to help the Elastic Observability users to quickly assess what is happening in their observed systems. You can help them visualise and analyze data, investigate their systems, perform root cause analysis or identify optimisation opportunities.
-
-  If the summarise and recall functions are NOT available, you do not have a working memory. Don't try to recall information via other functions.  If the user expects you to remember the previous conversations, tell them they can set up the knowledge base. A banner is available at the top of the conversation to set this up.
-
-  ONLY if the summarise and recall functions are available, the following applies:
-
-  You can use the "summarise" functions to store new information you have learned in a knowledge database. Once you have established that you did not know the answer to a question, and the user gave you this information, it's important that you create a summarisation of what you have learned and store it in the knowledge database. When you create this summarisation, make sure you craft it in a way that can be recalled with a semantic search later.
-
-  Additionally, you can use the "recall" function to retrieve relevant information from the knowledge database. Using the "recall" function will allow you to create a much more tailored and improved user experience. Assume the user has told you before.
-
-  For every question that the user asks, you, as the assistant, must query the knowledge base, no matter how confident you are in your response.
-
-  When the user starts a conversation, you as the assistant, MUST ALWAYS use the "recall" function to make sure you have enough context from the knowledge database to understand their question. DO NOT assume your knowledge is sufficient to answer the question appropriately. Make sure you mention this to the user in your first reply to them.
-
-  You do have access to private data that the user has shared with you in previous conversations.
-
-  Given this ability to store and recall data, it is very important to not make assumptions about the user's data or preferences, but rather, first query the knowledge database, and if nothing relevant comes up, ask the user for clarification. This is very important! They could be storing their data in any field, and in any data stream or index.
-
-  RIGHT:
-  User: "What is NASA"
-  Assistant executes recall function
-  Assistant answers question with data from recall function response
-
-  WRONG:
-  User: "What is NASA"
-  Assistant answers question without querying the knowledge
-
-  Here the part about summarise and recall ends.
-
-  You should autonomously execute functions - do not wait on the user's permission, but be proactive.
-
-  If you suspect the function you want to execute will change or delete the data in any way, confirm the function with the user first! This is very important.
-
-  Note that any visualisations will be displayed ABOVE your textual response, not below.
-
-  Before you call a function, make sure its name is correct.
-
-  Feel free to use Markdown in your replies, especially for code and query statements.`),
+      content: [
+        dedent(
+          `You are a helpful assistant for Elastic Observability. Your goal is to help the Elastic Observability users to quickly assess what is happening in their observed systems. You can help them visualise and analyze data, investigate their systems, perform root cause analysis or identify optimisation opportunities`
+        ),
+      ]
+        .concat(contexts.map((context) => context.description))
+        .join('\n'),
     },
   };
 }

--- a/x-pack/plugins/observability_ai_assistant/public/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/types.ts
@@ -61,7 +61,7 @@ export interface ObservabilityAIAssistantChatService {
   renderFunction: (
     name: string,
     args: string | undefined,
-    response: { data?: Serializable; content?: Serializable }
+    response: { data?: string; content?: string }
   ) => React.ReactNode;
 }
 

--- a/x-pack/plugins/observability_ai_assistant/public/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/types.ts
@@ -49,15 +49,8 @@ export interface PendingMessage {
   error?: any;
 }
 
-export interface ObservabilityAIAssistantService {
-  isEnabled: () => boolean;
-  chat: (options: {
-    messages: Message[];
-    connectorId: string;
-    knowledgeBaseAvailable: boolean;
-  }) => Observable<PendingMessage>;
-  callApi: ObservabilityAIAssistantAPIClient;
-  getCurrentUser: () => Promise<AuthenticatedUser>;
+export interface ObservabilityAIAssistantChatService {
+  chat: (options: { messages: Message[]; connectorId: string }) => Observable<PendingMessage>;
   getContexts: () => ContextDefinition[];
   getFunctions: (options?: { contexts?: string[]; filter?: string }) => FunctionDefinition[];
   executeFunction: (
@@ -72,9 +65,21 @@ export interface ObservabilityAIAssistantService {
   ) => React.ReactNode;
 }
 
-export interface ObservabilityAIAssistantPluginStart extends ObservabilityAIAssistantService {
-  registerContext: RegisterContextDefinition;
+export type ChatRegistrationFunction = ({}: {
+  signal: AbortSignal;
   registerFunction: RegisterFunctionDefinition;
+  registerContext: RegisterContextDefinition;
+}) => Promise<void>;
+
+export interface ObservabilityAIAssistantService {
+  isEnabled: () => boolean;
+  callApi: ObservabilityAIAssistantAPIClient;
+  getCurrentUser: () => Promise<AuthenticatedUser>;
+  start: ({}: { signal: AbortSignal }) => Promise<ObservabilityAIAssistantChatService>;
+}
+
+export interface ObservabilityAIAssistantPluginStart extends ObservabilityAIAssistantService {
+  register: (fn: ChatRegistrationFunction) => void;
 }
 
 export interface ObservabilityAIAssistantPluginSetup {}

--- a/x-pack/plugins/observability_ai_assistant/public/utils/builders.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/utils/builders.ts
@@ -15,7 +15,6 @@ type ChatItemBuildProps = Partial<ChatTimelineItem> & Pick<ChatTimelineItem, 'ro
 export function buildChatItem(params: ChatItemBuildProps): ChatTimelineItem {
   return {
     id: uniqueId(),
-    '@timestamp': new Date().toISOString(),
     title: '',
     canEdit: false,
     canGiveFeedback: false,

--- a/x-pack/plugins/observability_ai_assistant/public/utils/builders.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/utils/builders.ts
@@ -95,7 +95,7 @@ export function buildConversation(params?: Partial<Conversation>) {
       title: '',
       last_updated: '',
     },
-    messages: [getAssistantSetupMessage()],
+    messages: [getAssistantSetupMessage({ contexts: [] })],
     labels: {},
     numeric_labels: {},
     namespace: '',

--- a/x-pack/plugins/observability_ai_assistant/public/utils/get_timeline_items_from_conversation.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/utils/get_timeline_items_from_conversation.tsx
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { v4 } from 'uuid';
 import { i18n } from '@kbn/i18n';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
-import { type Message, MessageRole } from '../../common';
+import React from 'react';
+import { v4 } from 'uuid';
+import { Message, MessageRole } from '../../common';
 import type { ChatTimelineItem } from '../components/chat/chat_timeline';
 import { RenderFunction } from '../components/render_function';
 
@@ -30,7 +30,6 @@ export function getTimelineItemsfromConversation({
   return [
     {
       id: v4(),
-      '@timestamp': '',
       canCopy: false,
       canEdit: false,
       canGiveFeedback: false,
@@ -106,7 +105,6 @@ export function getTimelineItemsfromConversation({
 
       const props = {
         id: v4(),
-        '@timestamp': message['@timestamp'],
         canCopy: true,
         canEdit: hasConnector && (message.message.role === MessageRole.User || hasFunction),
         canGiveFeedback:


### PR DESCRIPTION
Moves chat logic into a separate service. This allows plugins to register components conditionally, e.g. based on a has-data check. Additionally, adds a `get_apm_timeseries` function. The system message is now also constructed from registered context definitions.